### PR TITLE
Only set BACKLIGHT_AUTO_OFF_PERIOD if not already defined

### DIFF
--- a/src/SpiLcd.h
+++ b/src/SpiLcd.h
@@ -79,10 +79,9 @@
 #define LCD_SHIFT_DATA_MASK 0xF0 // Data bits, QE = D4, QF = D5, QG = D6, QH = D7
 
 // Backlight is switched with a P-channel MOSFET, so signal is inverted.
-#ifdef BACKLIGHT_AUTO_OFF_PERIOD
-#undef BACKLIGHT_AUTO_OFF_PERIOD
-#endif
+#ifndef BACKLIGHT_AUTO_OFF_PERIOD
 #define BACKLIGHT_AUTO_OFF_PERIOD 600
+#endif
 
 class SpiLcd : public Print {
 	public:


### PR DESCRIPTION
Looks like Config.h is defining BACKLIGHT_AUTO_OFF_PERIOD, so only force a setting if it isn't already set