### PR TITLE
DS2413 actuators

### DIFF
--- a/htmljs/src/js/script-setup.js
+++ b/htmljs/src/js/script-setup.js
@@ -9,6 +9,12 @@ var devices = {
         } else if (f.h == 5) {
             g = window.extsensorContainer.cloneNode(true);
             g.querySelector("span.device-value").innerHTML = (typeof f.v === "undefined") ? "-" : f.v;
+        } else if (f.h == 3) {
+            g = window.owContainer.cloneNode(true);
+            g.querySelector("span.device-address").innerHTML = f.a;
+            g.querySelector("span.device-channel").innerHTML = f.n;
+            g.querySelector("select.device-pintype").value = f.x;
+            g.querySelector("span.device-value").innerHTML = (typeof f.v === "undefined") ? "-" : ((f.v) ? "active" : "inactive")
         } else {
             g = window.pinContainer.cloneNode(true);
             g.querySelector("select.device-pintype").value = f.x;
@@ -67,6 +73,10 @@ function cmdfrom(b) {
     c.p = a.p;
     if (c.h == 2) {
         c.a = a.a
+    } else if (c.h == 3) {
+        c.a = a.a;
+        c.n = a.n;
+        c.x = d.querySelector("select.device-pintype").value
     } else if (c.h == 1) {
         c.x = d.querySelector("select.device-pintype").value
     }
@@ -177,6 +187,7 @@ function init() {
     window.sensorContainer = detachNode(".device-container.sensor-device");
     window.pinContainer = detachNode(".device-container.pin-device");
     window.extsensorContainer = detachNode(".device-container.extsensor-device");
+    window.owContainer = detachNode(".device-container.ow-device");
 
     BWF.init({
         error: function(a) {

--- a/htmljs/src/setup.html
+++ b/htmljs/src/setup.html
@@ -260,7 +260,101 @@
         </div>
     </div>
 
-    <!-- build:include partials/footer.html -->
+    <div class='device-container ow-device'>
+        <table>
+            <tr>
+                <td ROWSPAN=2>
+                    <div class='device-title'></div>
+                    <br>
+                    <button>apply</button>
+                </td>
+                <td>
+                    <div class='device-setting-container'>
+                        <span class='setting-name'>Device slot</span>
+                        <select class='slot-select'>
+                            <option value='-1'>Unassigned</option>
+                            <option value='0'>0</option>
+                            <option value='1'>1</option>
+                            <option value='2'>2</option>
+                            <option value='3'>3</option>
+                            <option value='4'>4</option>
+                            <option value='5'>5</option>
+                            <option value='6'>6</option>
+                            <option value='7'>7</option>
+                            <option value='8'>8</option>
+                            <option value='9'>9</option>
+                            <option value='10'>10</option>
+                            <option value='11'>11</option>
+                            <option value='12'>12</option>
+                            <option value='13'>13</option>
+                            <option value='14'>14</option>
+                            <option value='15'>15</option>
+                        </select>
+                    </div>
+                </td>
+                <td>
+                    <div class='device-setting-container'>
+                        <span class='setting-name'>Hardware Type</span>
+                        <span class='setting-value device-type'>1-wire actuator</span>
+                    </div>
+                </td>
+                <td>
+                    <div class='device-setting-container device-address-container'>
+                        <span class='setting-name'>Address</span>
+                        <span class='setting-value device-address'></span>
+                    </div>
+                </td>
+                <td>
+                    <div class='device-setting-container device-channel-container'>
+                        <span class='setting-name'>Channel</span>
+                        <span class='setting-value device-channel'></span>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>
+                    <div class='device-setting-container'>
+                        <span class='setting-name'>Controller PIN</span>
+                        <span class='setting-value device-pin'></span>
+                    </div>
+                </td>
+                <td>
+                    <div class='device-setting-container'>
+                        <span class='setting-name'>Value</span>
+                        <span class='setting-value device-value'></span>
+                    </div>
+                </td>
+                <td>
+                    <div class='device-setting-container'>
+                        <span class='setting-name'>Function</span>
+                        <select class='setting-value device-function'>
+                            <option value=0>None</option>
+                            <option value=1>Chamber Door</option>
+                            <option value=2>Chamber Heater</option>
+                            <option value=3>Chamber Cooler</option>
+                            <option value=4>Chamber Light</option>
+                            <option value=7>Chamber Fan</option>
+                            <option value=14>Capper</option>
+                            <option value=15>PTC Cooler</option>
+
+                        </select>
+                    </div>
+                </td>
+                <td>
+                    <div class='device-setting-container device-pintype-container'>
+                        <span class='setting-name'>Pin type</span>
+                        <select class='setting-value device-pintype'>
+                            <option value=0>Not Inverted</option>
+                            <option value=1>Inverted</option>
+                        </select>
+                    </div>
+                </td>
+            </tr>
+        </table>
+    </div>
+</div>
+
+<!-- build:include partials/footer.html -->
     <!-- /build -->
 
     <div id="blockscreen" class="modal">

--- a/src/DS2413.h
+++ b/src/DS2413.h
@@ -86,7 +86,7 @@ public:
 	}
 
 	// assumes pio is either 0 or 1, which translates to masks 0x1 and 0x2
-	uint8_t pioMask(pio_t pio) { return pio++; }
+	uint8_t pioMask(pio_t pio) { return ++pio; }
 
 	/*
 	 * Reads the output state of a given channel, defaulting to a given value on error.


### PR DESCRIPTION
This branch contains a bugfix to DS2413.h, which is needed for one-wire actuators via DS2412 to work. Also, setup.html and script-setup.js are extended in order to work with DS2413 devices. I have tested the setup successfully with a single DS2413 (a BREWPI ONEWIRE SSR EXPANSION BOARD) that drives two SSRs.

setup.html and script-setup.js work fine with the new client under htmljs/src. I could not test them with the old client, which is shipped via the data_*.h files. Since the new client still is work in progress, I didn't commit any changes in the grunt configuration (which are tracked on my branch htmljs-development).