### PR TITLE
Fixed regex for spaces on log config page

### DIFF
--- a/htmljs/log.htm
+++ b/htmljs/log.htm
@@ -254,7 +254,7 @@
             var format = EI("format").value.trim();
 
             if (window.selectedMethod == "GET") {
-                var myRe = new RegExp("\s", "g");
+                var myRe = new RegExp(/\s/, "g");
                 if (myRe.exec(format)) {
                     alert("space is not allowed");
                     return;

--- a/htmljs/src/js/script-logging.js
+++ b/htmljs/src/js/script-logging.js
@@ -248,7 +248,7 @@ function generichttp_get() {
     var format = Q("#format").value.trim();
 
     if (window.selectedMethod == "GET") {
-        var myRe = new RegExp("\s", "g");
+        var myRe = new RegExp(/\s/, "g");
         if (myRe.exec(format)) {
             alert("<%= script_logging_space_not_allowed %>");
             return null;


### PR DESCRIPTION
The old way was not properly escaped, matching any string with s on log format