### PR TITLE
Upgrade Espressif 8266 from version 2.2.0 to 2.6.2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -10,8 +10,9 @@
 
 [platformio]
 #sonoff OTA no longer supported
-default_envs = classic, classic-spanish, classic-portuguese-br, classic-slovak, classic-tw, classic-it, newui, newui-tw, newui-spanish, newui-portuguese-br, newui-slovak,  newui-oled, newui-it, thorrax, sonoff, sonoff-esp8285 , thorrax-classic, esp32, d1pro, d1pro-classic
+;default_envs = classic, classic-spanish, classic-portuguese-br, classic-slovak, classic-tw, classic-it, newui, newui-tw, newui-spanish, newui-portuguese-br, newui-slovak,  newui-oled, newui-it, thorrax, sonoff, sonoff-esp8285 , thorrax-classic, esp32, d1pro, d1pro-classic
 ;default_envs = esp8266dev
+default_envs = classic
 
 [common_env_data]
 lib_deps_external = 
@@ -20,6 +21,8 @@ lib_deps_external =
 
 lib_deps_external_esp8266 = ${common_env_data.lib_deps_external} 
     OneWire
+
+
 
 [env:esp32-dev]
 platform = espressif32@~1.9.0
@@ -89,7 +92,7 @@ debug_port = /dev/cu.usbserial-00001014A
 
 
 [env:esp8266dev]
-platform = espressif8266@~2.2.0
+platform = espressif8266
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = 
@@ -109,8 +112,30 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 upload_port = /dev/cu.wchusbserial1410
 monitor_port = /dev/cu.wchusbserial1410
 
+[env:esp12e]
+platform = espressif8266
+board = esp12e
+framework = arduino
+lib_extra_dirs = 
+    ./lib-esp8266
+build_flags = -Wl,-Tesp8266.flash.4m2m.ld 
+    -DSerialDebug=true
+#    -DOLED_LCD=true
+#     -DUseClassicFrontEnd=true
+
+monitor_speed = 115200
+upload_speed = 115200
+
+lib_deps = ${common_env_data.lib_deps_external_esp8266} 
+
+#upload_port = /dev/cu.wchusbserial1420
+#monitor_port = /dev/cu.wchusbserial1420
+upload_port = /dev/cu.wchusbserial1410
+monitor_port = /dev/cu.wchusbserial1410
+
+
 [env:classic]
-platform = espressif8266@~2.2.0
+platform = espressif8266
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,8 +21,6 @@ lib_deps_external =
 lib_deps_external_esp8266 = ${common_env_data.lib_deps_external} 
     OneWire
 
-
-
 [env:esp32-dev]
 platform = espressif32@~1.9.0
 board = esp32dev

--- a/platformio.ini
+++ b/platformio.ini
@@ -10,9 +10,8 @@
 
 [platformio]
 #sonoff OTA no longer supported
-;default_envs = classic, classic-spanish, classic-portuguese-br, classic-slovak, classic-tw, classic-it, newui, newui-tw, newui-spanish, newui-portuguese-br, newui-slovak,  newui-oled, newui-it, thorrax, sonoff, sonoff-esp8285 , thorrax-classic, esp32, d1pro, d1pro-classic
+default_envs = classic, classic-spanish, classic-portuguese-br, classic-slovak, classic-tw, classic-it, newui, newui-tw, newui-spanish, newui-portuguese-br, newui-slovak,  newui-oled, newui-it, thorrax, sonoff, sonoff-esp8285 , thorrax-classic, esp32, d1pro, d1pro-classic
 ;default_envs = esp8266dev
-default_envs = classic
 
 [common_env_data]
 lib_deps_external = 
@@ -92,7 +91,7 @@ debug_port = /dev/cu.usbserial-00001014A
 
 
 [env:esp8266dev]
-platform = espressif8266
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = 
@@ -112,30 +111,8 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 upload_port = /dev/cu.wchusbserial1410
 monitor_port = /dev/cu.wchusbserial1410
 
-[env:esp12e]
-platform = espressif8266
-board = esp12e
-framework = arduino
-lib_extra_dirs = 
-    ./lib-esp8266
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld 
-    -DSerialDebug=true
-#    -DOLED_LCD=true
-#     -DUseClassicFrontEnd=true
-
-monitor_speed = 115200
-upload_speed = 115200
-
-lib_deps = ${common_env_data.lib_deps_external_esp8266} 
-
-#upload_port = /dev/cu.wchusbserial1420
-#monitor_port = /dev/cu.wchusbserial1420
-upload_port = /dev/cu.wchusbserial1410
-monitor_port = /dev/cu.wchusbserial1410
-
-
 [env:classic]
-platform = espressif8266
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -144,7 +121,7 @@ build_flags = -Wl,-Tesp8266.flash.4m2m.ld -DUseClassicFrontEnd=true
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:d1pro-classic]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = d1_mini_pro
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -154,7 +131,7 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 
 [env:d1pro]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = d1_mini_pro
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -163,7 +140,7 @@ build_flags = -Wl,-Tesp8266.flash.16m14m.ld
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:classic-spanish]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -173,7 +150,7 @@ build_flags = -Wl,-Tesp8266.flash.4m2m.ld -DUseClassicFrontEnd=true
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:classic-portuguese-br]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -183,7 +160,7 @@ build_flags = -Wl,-Tesp8266.flash.4m2m.ld -DUseClassicFrontEnd=true
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:classic-slovak]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -193,7 +170,7 @@ build_flags = -Wl,-Tesp8266.flash.4m2m.ld -DUseClassicFrontEnd=true
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:classic-tw]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -203,7 +180,7 @@ build_flags = -Wl,-Tesp8266.flash.4m2m.ld -DUseClassicFrontEnd=true
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:classic-it]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -214,7 +191,7 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:newui] 
 ;not yet working
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = d1_mini
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -224,7 +201,7 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 
 [env:newui-spanish]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -235,7 +212,7 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 
 [env:newui-portuguese-br]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -245,7 +222,7 @@ build_flags = -Wl,-Tesp8266.flash.4m2m.ld
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:newui-slovak]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -255,7 +232,7 @@ build_flags = -Wl,-Tesp8266.flash.4m2m.ld
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:newui-tw]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -265,7 +242,7 @@ build_flags = -Wl,-Tesp8266.flash.4m2m.ld
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:newui-it]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -275,7 +252,7 @@ build_flags = -Wl,-Tesp8266.flash.4m2m.ld
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:newui-oled]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -284,7 +261,7 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 
 [env:thorrax]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -292,7 +269,7 @@ build_flags = -Wl,-Tesp8266.flash.4m2m.ld -DBOARD=Thorrak_PCB
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:thorrax-classic]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -301,7 +278,7 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 
 [env:sonoff]
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = esp01_1m
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -309,7 +286,7 @@ build_flags = -Wl,-Tesp8266.flash.1m64.ld -DBOARD=Sonoff -DUseClassicFrontEnd=tr
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 #[env:sonoffota]
-#platform = espressif8266@~2.2.0
+#platform = espressif8266@~2.6.2
 #board = esp01_1m
 #framework = arduino
 #lib_extra_dirs = ./lib-esp8266
@@ -318,7 +295,7 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:sonoff-esp8285]
 board_build.flash_mode = dout
-platform = espressif8266@~2.2.0
+platform = espressif8266@~2.6.2
 board = esp01_1m
 framework = arduino
 lib_extra_dirs = ./lib-esp8266
@@ -329,7 +306,7 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 #[env:sonoffota-esp8285]
 #board_build.flash_mode = dout
 #board = esp01_1m
-#platform = espressif8266@~2.2.0
+#platform = espressif8266@~2.6.2
 #framework = arduino
 #lib_extra_dirs = ./lib-esp8266
 #build_flags = -Wl,-Tesp8266.flash.1m64.ld -DBOARD=Sonoff -DNO_SPIFFS -DUseClassicFrontEnd=true


### PR DESCRIPTION
This is only an upgrade of the Espressif8266 library. With the old version 2.2.0, I get the error below when compiling. With the new version, everything compiles. I have not tested the running software, as my only USB cable broke.  

<removed_home_catalog>/.platformio/packages/framework-arduinoespressif8266@2.20502.0/cores/esp8266/core_esp8266_main.cpp:243:79: error: section of alias 'void app_entry_custom()' must match section of its target
  243 | static void ICACHE_RAM_ATTR __attribute__((weakref("app_entry_redefinable"))) app_entry_custom (void);