### PR TITLE
Fix PTC control page

### DIFF
--- a/src/BrewPiLess.cpp
+++ b/src/BrewPiLess.cpp
@@ -942,7 +942,7 @@ void greeting(std::function<void(const char*)> sendFunc)
 #endif		 
 #if EanbleParasiteTempControl
 	
-	doc["ptc"]= serialized(parasiteTempController.getSettings());
+	doc["ptcs"]= serialized(parasiteTempController.getSettings());
 #endif
 
 #if EnableDHTSensorSupport


### PR DESCRIPTION
This commit fixed PTC control page. At this moment "Glycol Temperature Control" is not shown.