### PR TITLE
Added functionality to expose prometheus metrics

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -644,6 +644,9 @@
 #define FileSystem SPIFFS
 #endif
 
+#ifndef METRICS
+#define METRICS true
+#endif
 
 #if ESP32
 // when read logs, ESP32, or AsyncTCP to be exact, would request 5623 bytes


### PR DESCRIPTION
I have added a "/metrics" page in order to be able to collect metrics with prometheus.

Output looks like this with instance name derived from config "Title"
```
brewpi_beer_temp{instance="testmachine"} 0
brewpi_beer_set{instance="testmachine"} 20.00
brewpi_fridge_temp{instance="testmachine"} 0
brewpi_fridge_set{instance="testmachine"} 20.00
brewpi_room_temp{instance="testmachine"} 0
```