### PR TITLE
Replace deprecated build flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -145,13 +145,12 @@ platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -g -Wl,-Tesp8266.flash.4m2m.ld 
-    -DFilterPressureReading=true
+board_build.ldscript = eagle.flash.4m2m.ld
+build_flags = -g -DFilterPressureReading=true
     -DEnableHumidityControlSupport=true
     -DSerialDebug=true
 #    -DOLED_LCD=true
 
-board_build.ldscript = eagle.flash.4m2m.ld
 monitor_filters= esp8266_exception_decoder
 
 monitor_speed = 115200
@@ -169,9 +168,6 @@ platform = ${common_env_data.esp8266_framework}
 board = d1_mini_pro
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.16m14m.ld
-
-board_build.ldscript = eagle.flash.16m14m.ld
 
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
@@ -181,7 +177,7 @@ platform = ${common_env_data.esp8266_framework}
 board = d1_mini
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld 
+board_build.ldscript = eagle.flash.4m2m.ld
 
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
@@ -191,8 +187,8 @@ platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld
-    -DWebPageLanguage=spanish
+board_build.ldscript = eagle.flash.4m2m.ld
+build_flags = -DWebPageLanguage=spanish
 
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
@@ -202,8 +198,8 @@ platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld
-    -DWebPageLanguage=portuguese-br
+board_build.ldscript = eagle.flash.4m2m.ld
+build_flags = -DWebPageLanguage=portuguese-br
 
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
@@ -212,8 +208,8 @@ platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld
-    -DWebPageLanguage=slovak
+board_build.ldscript = eagle.flash.4m2m.ld
+build_flags = -DWebPageLanguage=slovak
 
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
@@ -222,8 +218,8 @@ platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld
-    -DWebPageLanguage=chinese
+board_build.ldscript = eagle.flash.4m2m.ld
+build_flags = -DWebPageLanguage=chinese
 
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
@@ -232,8 +228,8 @@ platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld
-    -DWebPageLanguage=italian
+board_build.ldscript = eagle.flash.4m2m.ld
+build_flags = -DWebPageLanguage=italian
 
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
@@ -242,8 +238,8 @@ platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld
-    -DWebPageLanguage=norwegian
+board_build.ldscript = eagle.flash.4m2m.ld
+build_flags = -DWebPageLanguage=norwegian
 
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
@@ -253,7 +249,8 @@ platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld -DOLED_LCD=true 
+board_build.ldscript = eagle.flash.4m2m.ld
+build_flags = -DOLED_LCD=true
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 
@@ -262,7 +259,8 @@ platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld -DOLED_LCD=true -DISPINDEL_DISPLAY=true
+board_build.ldscript = eagle.flash.4m2m.ld
+build_flags = -DOLED_LCD=true -DISPINDEL_DISPLAY=true
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:thorrax]
@@ -270,7 +268,8 @@ platform = ${common_env_data.esp8266_framework}
 board = nodemcuv2
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.4m2m.ld -DBOARD=Thorrak_PCB
+board_build.ldscript = eagle.flash.4m2m.ld
+build_flags = -DBOARD=Thorrak_PCB
 lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 
@@ -279,7 +278,8 @@ platform = ${common_env_data.esp8266_framework}
 board = esp01_1m
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.1m64.ld -DBOARD=Sonoff 
+board_build.ldscript = eagle.flash.1m64.ld
+build_flags = -DBOARD=Sonoff
     -DBREWPI_LCD=false -DBREWPI_MENU=false -DBREWPI_BUTTONS=false
     -DDEVELOPMENT_OTA=false -DAUTO_CAP=false -DSupportPressureTransducer=false 
     -DEanbleParasiteTempControl=false
@@ -292,7 +292,8 @@ lib_deps = ${common_env_data.lib_deps_external_esp8266}
 #board = esp01_1m
 #framework = arduino
 #lib_extra_dirs = ${common_env_data.esp8266_lib}
-#build_flags = -Wl,-Tesp8266.flash.1m64.ld -DBOARD=Sonoff -DNO_SPIFFS -DUseClassicFrontEnd=true
+#board_build.ldscript = eagle.flash.1m64.ld
+#build_flags = -DBOARD=Sonoff -DNO_SPIFFS -DUseClassicFrontEnd=true
 #lib_deps = ${common_env_data.lib_deps_external_esp8266}
 
 [env:sonoff-esp8285]
@@ -301,7 +302,8 @@ platform = ${common_env_data.esp8266_framework}
 board = esp01_1m
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.1m64.ld -DBOARD=Sonoff 
+board_build.ldscript = eagle.flash.1m64.ld
+build_flags = -DBOARD=Sonoff
     -DBREWPI_LCD=false -DBREWPI_MENU=false -DBREWPI_BUTTONS=false
     -DDEVELOPMENT_OTA=false -DAUTO_CAP=false -DSupportPressureTransducer=false 
     -DEanbleParasiteTempControl=false
@@ -318,7 +320,8 @@ platform = ${common_env_data.esp8266_framework}
 board = esp01_1m
 framework = arduino
 lib_extra_dirs = ${common_env_data.esp8266_lib}
-build_flags = -Wl,-Tesp8266.flash.1m64.ld -DBOARD=Sonoff 
+board_build.ldscript = eagle.flash.1m64.ld
+build_flags = -DBOARD=Sonoff
     -DBREWPI_LCD=false -DBREWPI_MENU=false -DBREWPI_BUTTONS=false
     -DDEVELOPMENT_OTA=false -DAUTO_CAP=false -DSupportPressureTransducer=false 
     -DEanbleParasiteTempControl=false -DSONOFF_USE_AM2301=true


### PR DESCRIPTION
For the d1pro, we are already using the default linker script, so this was removed.

For the esp8266 boards that specified 'esp8266.flash.4m2m.ld', this was silently overridden to 'eagle.flash.4m2m.ld'.