### PR TITLE
Flush data to flash on ESP8266 and ESP32

### DIFF
--- a/src/BrewLogger.cpp
+++ b/src/BrewLogger.cpp
@@ -384,10 +384,8 @@ BrewLogger::BrewLogger(void){
 				if(wlen != _logIndex){
 					DBG_PRINTF("!!!write failed @ %d\n",_logIndex);
 				}
-				#if ESP32
 				#if UseLittleFS
 				_logFile.flush();
-				#endif
 				#endif
 			}
 		}
@@ -1082,11 +1080,8 @@ BrewLogger::BrewLogger(void){
 				if(wlen != _logIndex){
 					DBG_PRINTF("!!!write failed @ %d\n",_logIndex);
 				}
-				#if ESP32
 				#if UseLittleFS
 				_logFile.flush();
-				#endif
-
 				#endif
 			}
 
@@ -1137,13 +1132,10 @@ BrewLogger::BrewLogger(void){
 				int nlen = len  + idx -LogBufferSize;
 				wlen += _logFile.write((const uint8_t*)buf,nlen);
 			}
-			#if ESP32
 			#if UseLittleFS
 			_logFile.flush();
 			#endif
-			#endif
 		}
-		
 	}
 
 	void BrewLogger::_addGravityRecord(bool isOg, uint16_t gravity){


### PR DESCRIPTION
When we write logs, we need to flush the data to flash, so we don't lose it. This was not possible on ESP8266 because of definitions to only allow ESP32 access to these functions. This restriction is now removed.

This change should fix #370 