### PR TITLE
fix: Adjust actuator pins for 20A versions Sonoff ESP32 devices

### DIFF
--- a/src/Config.h
+++ b/src/Config.h
@@ -356,11 +356,11 @@
 
 #define oneWirePin 25
 
-#define actuatorPin1  21  // This is relay 1
+#define actuatorPin1  21  // Relay 1 in 16A versions
 #define actuatorPin2  23  // TM1621 RD
 #define actuatorPin3  5   // TM1621 DAT
-#define actuatorPin4  24  
-#define actuatorPin5  26
+#define actuatorPin4  19  // Relay 1 in 20A versions
+#define actuatorPin5  22  // Relay 2 in 20A versions
 #else // SONOFF_NEWGEN ends
 
 #define PIN_SDA 21


### PR DESCRIPTION
Adjust actuator pins for 20A version Sonoff ESP32 devices