### PR TITLE
Support for Sonoff TH Elite 20A and TH Origin 20A

### DIFF
--- a/docs/12.HardwareSONOFF.md
+++ b/docs/12.HardwareSONOFF.md
@@ -16,8 +16,12 @@ The sensor that has the RJ9 connector comes with a controller in the wire that n
 Option 1: Remove the controller and reconntect the wires (not tested).
 Option 2: Use  `Sonoff AL010 2.5mm Audio Jack to RJ9 Adapter` with the old sensor using the audio jack conntector.
 
-##### Connecting OLED LCD (optional)
+#### Connecting OLED LCD (optional)
 * Connect SDA to WR solder pad
 * Connect SCL to CS solder pad
 * Use hotglue over soldered contacts so that you don't ripoff the solder pads accidentally. 
 * Connect 3v and Gnd to corresponding solderpads
+
+#### 🚧 Workaround for 20A Sonoff Origin and Elite
+
+20A Sonoff devices use bi-stable or latching relays controlled by 2 pins. One pin need to be assigned as Chamber heater even though there is no heater.. In that way when the cooler pin turns off and the fridge is not really off. But soon the algorithm would kick in and start the heater that does not exist and that would turn the fridge off.

--- a/docs/12.HardwareSONOFF.md
+++ b/docs/12.HardwareSONOFF.md
@@ -11,6 +11,10 @@ Please note that some older SONOFFs, maybe before 2018, use ESP8266 while new on
 
 For Sonoff TH Elite the built-in lcd display can be removed and a OLED LCD screen can be connected in it's place.. Use electrical tape to make sure that the LCD pcb is not touching the main pcb. The front glass is a thin plastic be gentle with it. 
 
+##### Relay Pins
+16A devices: 21
+20A devices: 19 and 22 for the latching relay
+
 #### Conntecting sensor
 The sensor that has the RJ9 connector comes with a controller in the wire that needs to be removed
 Option 1: Remove the controller and reconntect the wires (not tested).

--- a/platformio.ini
+++ b/platformio.ini
@@ -156,6 +156,7 @@ build_flags =
     -DEanbleParasiteTempControl=false
     -DEnableBME280Support=false
     -DSONOFF_NEWGEN=true
+    -DLATCHING_RELAYS=true -DLATCH_PIN_SET=22 -DLATCH_PIN_RESET=19
 
 monitor_speed = 115200
 lib_deps = ${common_env_data.lib_deps_external_esp32} 

--- a/platformio.ini
+++ b/platformio.ini
@@ -140,7 +140,7 @@ build_flags =
 monitor_speed = 115200
 lib_deps = ${common_env_data.lib_deps_external_esp32} 
 
-[env:esp32-sonoff]  # for newgen sonoff devices like sonoff elite and origin
+[env:sonoff-thr316] # Sonoff TH Elite 16A (THR316D) and Sonoff TH Origin 16A (THR316)
 platform = ${common_env_data.esp32_framework}
 board = esp32dev
 framework = arduino
@@ -156,7 +156,27 @@ build_flags =
     -DEanbleParasiteTempControl=false
     -DEnableBME280Support=false
     -DSONOFF_NEWGEN=true
-    -DLATCHING_RELAYS=true -DLATCH_PIN_SET=22 -DLATCH_PIN_RESET=19
+
+monitor_speed = 115200
+lib_deps = ${common_env_data.lib_deps_external_esp32}
+
+
+[env:sonoff-thr320] # Sonoff TH Elite 20A (THR320D) and Sonoff TH Origin 20A (THR320)
+platform = ${common_env_data.esp32_framework}
+board = esp32dev
+framework = arduino
+board_build.mcu = esp32
+lib_extra_dirs = ${common_env_data.esp32_lib}
+
+board_build.partitions = ./partition2.csv
+
+build_flags =
+    -DOLED_LCD=true 
+    -DSerialDebug=false
+    -DEnableHumidityControlSupport=false
+    -DEanbleParasiteTempControl=false
+    -DEnableBME280Support=false
+    -DSONOFF_NEWGEN=true -DSONOFF_THR320
 
 monitor_speed = 115200
 lib_deps = ${common_env_data.lib_deps_external_esp32} 

--- a/src/ActuatorArduinoPin.h
+++ b/src/ActuatorArduinoPin.h
@@ -9,6 +9,10 @@
 
 #include "Actuator.h"
 
+#ifndef LATCHING_RELAYS
+#define LATCHING_RELAYS false
+#endif
+
 template<uint8_t pin, bool invert>
 class DigitalConstantPinActuator ACTUATOR_BASE_CLASS_DECL
 {
@@ -47,7 +51,20 @@ class DigitalPinActuator ACTUATOR_BASE_CLASS_DECL
 
 	inline ACTUATOR_METHOD void setActive(bool active) {
 		this->active = active;
-		digitalWrite(pin, active^invert ? HIGH : LOW);
+
+		#if LATCHING_RELAYS // Latching relay
+			if (active) {
+				digitalWrite(LATCH_PIN_SET, HIGH);
+				delay(10);
+				digitalWrite(LATCH_PIN_SET, LOW);
+			} else {
+				digitalWrite(LATCH_PIN_RESET, HIGH);
+				delay(10);
+				digitalWrite(LATCH_PIN_RESET, LOW);
+			}
+		#else
+			digitalWrite(pin, active^invert ? HIGH : LOW);
+		#endif
 	}
 
 	bool isActive() { return active; }

--- a/src/ActuatorArduinoPin.h
+++ b/src/ActuatorArduinoPin.h
@@ -9,8 +9,9 @@
 
 #include "Actuator.h"
 
-#ifndef LATCHING_RELAYS
-#define LATCHING_RELAYS false
+#ifdef SONOFF_THR320
+#define LATCH_PIN_SET 22
+#define LATCH_PIN_RESET 19
 #endif
 
 template<uint8_t pin, bool invert>
@@ -52,18 +53,18 @@ class DigitalPinActuator ACTUATOR_BASE_CLASS_DECL
 	inline ACTUATOR_METHOD void setActive(bool active) {
 		this->active = active;
 
-		#if LATCHING_RELAYS // Latching relay
-			if (active) {
-				digitalWrite(LATCH_PIN_SET, HIGH);
-				delay(10);
-				digitalWrite(LATCH_PIN_SET, LOW);
-			} else {
-				digitalWrite(LATCH_PIN_RESET, HIGH);
-				delay(10);
-				digitalWrite(LATCH_PIN_RESET, LOW);
-			}
+		#ifdef SONOFF_THR320
+		if (active) {
+			digitalWrite(LATCH_PIN_SET, HIGH);
+			delay(10);
+			digitalWrite(LATCH_PIN_SET, LOW);
+		} else {
+			digitalWrite(LATCH_PIN_RESET, HIGH);
+			delay(10);
+			digitalWrite(LATCH_PIN_RESET, LOW);
+		}
 		#else
-			digitalWrite(pin, active^invert ? HIGH : LOW);
+		digitalWrite(pin, active^invert ? HIGH : LOW);
 		#endif
 	}
 

--- a/src/Config.h
+++ b/src/Config.h
@@ -356,11 +356,11 @@
 
 #define oneWirePin 25
 
-#define actuatorPin1  21  // This is relay 1
+#define actuatorPin1  21  // Relay 1 in 16A versions
 #define actuatorPin2  23  // TM1621 RD
 #define actuatorPin3  5   // TM1621 DAT
-#define actuatorPin4  24  
-#define actuatorPin5  26
+#define actuatorPin4  19  // Relay 1 in 20A versions
+#define actuatorPin5  22  // Relay 2 in 20A versions
 #else // SONOFF_NEWGEN ends
 
 #define PIN_SDA 21

--- a/src/Config.h
+++ b/src/Config.h
@@ -359,8 +359,8 @@
 #define actuatorPin1  21  // Relay 1 in 16A versions
 #define actuatorPin2  23  // TM1621 RD
 #define actuatorPin3  5   // TM1621 DAT
-#define actuatorPin4  19  // Relay 1 in 20A versions
-#define actuatorPin5  22  // Relay 2 in 20A versions
+#define actuatorPin4  19  // Relay 1 in 20A versions. Latching relay needs 2 pins
+#define actuatorPin5  22  // Relay 1 in 20A versions
 #else // SONOFF_NEWGEN ends
 
 #define PIN_SDA 21


### PR DESCRIPTION
This PR adds support for Sonoff TH Elite 20A and TH Origin 20A which use a double-coil latching relay. The pins to control the relay are hardcoded since they're defined by these devices and cannot be changed. A more elegant solution could be to introduce new pin types such as "Latching SET" and "Latching RESET" but since I haven't found any requests for latching relays it's probably not worth the effort.