### PR TITLE
Fix 4.4 build error for SONOFF_NEWGEN code

### DIFF
--- a/src/BrewPiLess.cpp
+++ b/src/BrewPiLess.cpp
@@ -1702,12 +1702,12 @@ void handleReset()
 
 void brewpi_setup()
 {
-	if (SONOFF_NEWGEN) {
+#if SONOFF_NEWGEN	
 		pinMode(sensorPowerPin, OUTPUT);  // Power for sonoff temp sensor
 		digitalWrite(sensorPowerPin, HIGH);
 		pinMode(powerIndicatorPin, OUTPUT); 
 		digitalWrite(powerIndicatorPin, LOW); // Red power led	
-	}
+#endif	
 #if defined(ESP8266)
 	// We need to initialize the EEPROM on ESP8266
 	EEPROM.begin(MAX_EEPROM_SIZE_LIMIT);

--- a/src/TempControl.cpp
+++ b/src/TempControl.cpp
@@ -78,9 +78,9 @@ uint16_t TempControl::waitTime;
 #endif
 
 void TempControl::init(void){
-	if (SONOFF_NEWGEN) {
+#if SONOFF_NEWGEN
 		pinMode(relayIndicatorPin, OUTPUT);
-	}
+#endif	
 	state=IDLE;
 	cs.mode = MODE_OFF;
 
@@ -402,12 +402,14 @@ void TempControl::updateOutputs(void) {
 	heater->setActive(!cc.lightAsHeater && heating);
 	light->setActive(isDoorOpen() || (cc.lightAsHeater && heating) || cameraLightState.isActive());
 	fan->setActive(heating || cooling);
-	if (SONOFF_NEWGEN && (heating || cooling)) {
+#if SONOFF_NEWGEN
+	if (heating || cooling) {
   		digitalWrite(relayIndicatorPin, LOW);
 	}
 	else {
 		digitalWrite(relayIndicatorPin, HIGH);
 	}
+#endif	
 }
 
 

--- a/src/WiFiSetup.cpp
+++ b/src/WiFiSetup.cpp
@@ -84,9 +84,9 @@ bool WiFiSetupClass::isApMode(){
 void WiFiSetupClass::begin(WiFiMode mode, char const *ssid,const char *passwd,char const* targetSSID,const char *targetPass)
 {
 	wifi_info("begin:");
-	if(SONOFF_NEWGEN) {
+#if SONOFF_NEWGEN
 		pinMode(wifiIndicatorPin, OUTPUT); // Blue Wifi led
-	}
+#endif
 	if(targetSSID && targetSSID[0]){
 		if(_targetSSID) free((void*)_targetSSID);
 		_targetSSID=strdup(targetSSID);
@@ -195,9 +195,9 @@ String WiFiSetupClass::status(void){
 
 bool WiFiSetupClass::stayConnected(void)
 {
-	if(SONOFF_NEWGEN) {
+#if SONOFF_NEWGEN	
 		digitalWrite(wifiIndicatorPin, HIGH);
-	}
+#endif	
 	if(WiFi.getMode() == WIFI_AP || WiFi.getMode() == WIFI_AP_STA){
 		dnsServer->processNextRequest();
 //		if(_mode == WIFI_AP) return true;
@@ -348,9 +348,9 @@ bool WiFiSetupClass::stayConnected(void)
  	} // WiFi.status() != WL_CONNECTED 
  	else // connected
  	{
-		 if(SONOFF_NEWGEN) {
+#if SONOFF_NEWGEN		 
 		 	digitalWrite(wifiIndicatorPin, LOW);
-		 }
+#endif		 
 		 if(_mode == WIFI_AP){
 			 DBG_PRINTF("Connected in AP_mode\n");
 		 }else{


### PR DESCRIPTION
This PR fix SONOFF missconfiguation for SONOFF_NEWGEN blocks that use invalid pin configuration for another devices than SONOFF newgen